### PR TITLE
fix browser driver search to use $PATH env var instead of hardcoded paths

### DIFF
--- a/src/aqc4all/login.py
+++ b/src/aqc4all/login.py
@@ -17,13 +17,6 @@ import requests
 import shutil
 import pyotp
 
-def get_browser_driver_path(browser_name):
-    candidates = ["/usr/bin", "/usr/local/bin", shutil.which(browser_name)]
-    for path in filter(None, candidates):
-        if shutil.which(browser_name, path=path):
-            return shutil.which(browser_name, path=path)
-    return shutil.which(browser_name, path=path)
-
 def launch_browser(args, USER_AGENT):
     browser_choice = args.browser.lower() if args.browser else "chromium"
 
@@ -32,8 +25,8 @@ def launch_browser(args, USER_AGENT):
         os.environ["TMPDIR"] = os.path.expanduser("~/tmp")
         os.makedirs(os.environ["TMPDIR"], exist_ok=True)
 
-        geckodriver_path = get_browser_driver_path("geckodriver")
-        if not geckodriver_path:
+        geckodriver_path = shutil.which("geckodriver")
+        if geckodriver_path is None:
             raise FileNotFoundError("geckodriver not found in PATH")
 
         print("[+] Running with Firefox browser (private mode)")
@@ -59,8 +52,8 @@ def launch_browser(args, USER_AGENT):
         return webdriver.Firefox(service=service, options=options)
 
     elif browser_choice == "chromium":
-        chromedriver_path = get_browser_driver_path("chromedriver")
-        if not chromedriver_path:
+        chromedriver_path = shutil.which("chromedriver")
+        if chromedriver_path is None:
             raise FileNotFoundError("chromedriver not found in PATH")
 
         options = ChromeOptions()


### PR DESCRIPTION
NixOS uses `~/.nix-profile/bin` instead of `/usr/bin` or `/usr/local/bin` for user installed programs. The current version of the script does not properly search the user's $PATH environment variable to find `geckodriver` or `chromedriver`, which is only noticeable when the user doesn't use `/usr/bin` or `/usr/local/bin` as they are hardcoded paths.

I believe `get_browser_driver()` can be removed and just replaced with `shutil.which()` to search the user's path. This fixed the issue for me on NixOS where it was unable to find `geckodriver`.

I've only tested this on NixOS, but I think this should just work regardless of distribution.